### PR TITLE
fix: Glances API v4 compatibility and response.json() await issue

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,3 @@
 """GlanceWatch - Lightweight monitoring adapter for Glances + Uptime Kuma."""
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -41,24 +41,28 @@ class GlancesMonitor:
             raise RuntimeError("Monitor not initialized. Use 'async with' context manager.")
         
         try:
-            # Try with the configured base URL first, if it doesn't end with /api/X, try both v3 and v4
-            url = f"/{endpoint}" if self.config.glances_base_url.endswith(("/api/3", "/api/4")) else f"/api/3/{endpoint}"
+            # Try API v4 first (Glances 4.x), then fall back to v3 (Glances 3.x)
+            if self.config.glances_base_url.endswith(("/api/3", "/api/4")):
+                url = f"/{endpoint}"
+            else:
+                url = f"/api/4/{endpoint}"  # Try v4 first
+            
             logger.debug(f"Fetching Glances endpoint: {url}")
             response = await self.client.get(url)
             response.raise_for_status()
-            data = await response.json()
+            data = response.json()
             logger.debug(f"Received data from {endpoint}: {data}")
             return data
         except httpx.HTTPStatusError as e:
-            # If 404, try API v4
-            if e.response.status_code == 404 and "/api/3/" in url:
+            # If 404 on v4, try API v3 (for older Glances versions)
+            if e.response.status_code == 404 and "/api/4/" in url:
                 try:
-                    url = url.replace("/api/3/", "/api/4/")
-                    logger.debug(f"Retrying with API v4: {url}")
+                    url = url.replace("/api/4/", "/api/3/")
+                    logger.debug(f"Retrying with API v3: {url}")
                     response = await self.client.get(url)
                     response.raise_for_status()
-                    data = await response.json()
-                    logger.debug(f"Received data from {endpoint} (v4): {data}")
+                    data = response.json()
+                    logger.debug(f"Received data from {endpoint} (v3): {data}")
                     return data
                 except Exception:
                     pass

--- a/docs/MULTI-PLATFORM-RELEASE.md
+++ b/docs/MULTI-PLATFORM-RELEASE.md
@@ -78,7 +78,7 @@ Users can now install GlanceWatch using their preferred package manager:
 
 ## Repository Links
 
-- **Main Repository**: https://github.com/collynes/glanceswatch
+- **Main Repository**: https://github.com/collynes/glancewatch
 - **Homebrew Tap**: https://github.com/collynes/homebrew-glancewatch
 - **PyPI Package**: https://pypi.org/project/glancewatch/
 - **npm Package**: https://www.npmjs.com/package/glancewatch

--- a/glancewatch.rb
+++ b/glancewatch.rb
@@ -3,7 +3,7 @@ class Glancewatch < Formula
 
   desc "Lightweight monitoring adapter for Glances + Uptime Kuma"
   homepage "https://github.com/collynes/glancewatch"
-  url "https://files.pythonhosted.org/packages/source/g/glancewatch/glancewatch-1.2.5.tar.gz"
+  url "https://files.pythonhosted.org/packages/source/g/glancewatch/glancewatch-1.2.6.tar.gz"
   sha256 "e8be9f780e30ee96a2f2bc6da885a048a8dd37fa44bac09adaeb5b3fd7b32efd"
   license "MIT"
 
@@ -13,7 +13,7 @@ class Glancewatch < Formula
     # Install glancewatch and all dependencies via pip (uses pre-built wheels)
     system "python3.12", "-m", "venv", libexec
     system libexec/"bin/pip", "install", "--upgrade", "pip"
-    system libexec/"bin/pip", "install", "glancewatch==1.2.5"
+    system libexec/"bin/pip", "install", "glancewatch==1.2.6"
     
     # Create wrapper script
     bin.install_symlink libexec/"bin/glancewatch"

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glancewatch",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Lightweight monitoring adapter for Glances + Uptime Kuma",
   "main": "index.js",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include-package-data = true
 
 [project]
 name = "glancewatch"
-version = "1.2.5"
+version = "1.2.6"
 description = "Lightweight monitoring adapter bridging Glances metrics with Uptime Kuma"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Bug Fixes in v1.2.6:

- **Fix Glances 4.x API compatibility**: Now tries API v4 first, falls back to v3
- **Fix response.json() await error**: httpx response.json() returns dict directly, not coroutine
- Resolves 0.0% metrics and 404 errors with Glances 4.x

These issues were introduced in v1.2.5 when updating glances dependency to >=4.0.0

